### PR TITLE
sets cookie to expire an hour after being set

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,7 @@ interface SessionOptions {
   resave: boolean;
   cookie: {
     httpOnly: boolean;
+    maxAge: number;
   };
   store?: redis.RedisStore;
 }
@@ -41,7 +42,8 @@ const sessionOptions: SessionOptions = {
   saveUninitialized: false,
   resave: false,
   cookie: {
-    httpOnly: false
+    httpOnly: false,
+    maxAge: 1000 * 60 * 60
   }
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,7 @@ interface SessionOptions {
   secret: string;
   saveUninitialized: boolean;
   resave: boolean;
+  rolling: boolean;
   cookie: {
     httpOnly: boolean;
     maxAge: number;
@@ -41,6 +42,7 @@ const sessionOptions: SessionOptions = {
   secret: process.env.SESSION_SECRET || 'dx',
   saveUninitialized: false,
   resave: false,
+  rolling: true,
   cookie: {
     httpOnly: false,
     maxAge: 1000 * 60 * 60


### PR DESCRIPTION
Set's the servers cookie to expire an hour after login, depends on the front-end to handle redirecting expired cookie users (HTTP 401's) back to the home page to force a fresh login