### PR TITLE
fixes bug when refresh token is invalid and needs to be removed

### DIFF
--- a/src/api/models/user.ts
+++ b/src/api/models/user.ts
@@ -178,7 +178,7 @@ class User {
    */
   static updateCanvasData = async (
     props: User,
-    canvasRefreshToken: string,
+    canvasRefreshToken: string | null,
     canvasOptIn: boolean
   ): Promise<User> => {
     try {
@@ -188,13 +188,17 @@ class User {
         Key: {
           osuId: { N: user.osuId.toString() }
         },
-        UpdateExpression: 'SET canvasRefreshToken = :crt, canvasOptIn = :coi',
-        ExpressionAttributeValues: {
-          ':coi': { BOOL: canvasOptIn },
-          ':crt': { S: canvasRefreshToken }
-        },
         ReturnValues: 'NONE'
       };
+      params.UpdateExpression = 'SET canvasRefreshToken = :crt, canvasOptIn = :coi';
+      params.ExpressionAttributeValues = {
+        ':coi': { BOOL: canvasOptIn },
+        ':crt': { S: canvasRefreshToken }
+      };
+      if (canvasRefreshToken === null) {
+        params.UpdateExpression = 'SET canvasOptIn = :coi';
+        params.ExpressionAttributeValues = { ':coi': { BOOL: canvasOptIn } };
+      }
       const result: AWS.DynamoDB.UpdateItemOutput = await asyncTimedFunction(
         updateItem,
         'User:updateItem',

--- a/src/api/modules/canvas.ts
+++ b/src/api/modules/canvas.ts
@@ -70,7 +70,7 @@ export const performRefresh = async (u: User): Promise<User> => {
   } catch (err) {
     logger.error('canvas.performRefresh token error:', err);
     // Refresh token is no longer valid and we must update the database
-    await updateOAuthData(user, { isCanvasOptIn: false, account: { refreshToken: '' } });
+    await updateOAuthData(user, { isCanvasOptIn: false, account: { refreshToken: null } });
     user.canvasOauthToken = null;
     user.canvasOauthExpire = null;
     user.isCanvasOptIn = false;


### PR DESCRIPTION
DynamoDb doesn't allow empty string parameter values, this fixes the bug.