### PR TITLE
fixes missing audiences and unpublished announcements

### DIFF
--- a/src/api/modules/dx.ts
+++ b/src/api/modules/dx.ts
@@ -68,16 +68,22 @@ const iconUrl = item => {
  * @param items a list of items to reshape as announcement results
  */
 const mappedAnnouncements = (items: any[]): IAnnouncementResult[] => {
-  return items.map(d => ({
-    id: d.id,
-    type: d.drupal_internal__name,
-    date: d.date,
-    title: d.title,
-    body: d.field_announcement_body,
-    bg_image: imageUrl(d),
-    audiences: d.field_audience.map(a => a.name),
-    action: itemAction(d)
-  }));
+  return items
+    .filter(d => d.title !== undefined)
+    .map(d => {
+      let audiences = [];
+      if (d.field_audience !== undefined) audiences = d.field_audience.map(a => a.name);
+      return {
+        id: d.id,
+        type: d.drupal_internal__name,
+        date: d.date,
+        title: d.title,
+        body: d.field_announcement_body,
+        bg_image: imageUrl(d),
+        audiences,
+        action: itemAction(d)
+      };
+    });
 };
 
 /**


### PR DESCRIPTION
When an entity queue announcement is unpublished it will still be visible in the related API call but without a title, this will filter those out.. also sets audiences to an empty array if they aren't included in the data payload.