### PR TITLE
fixes bug with related fields having unset name values in Drupal

### DIFF
--- a/src/api/__tests__/announcements.test.ts
+++ b/src/api/__tests__/announcements.test.ts
@@ -14,6 +14,33 @@ import { setAsync, getAsync, mockCachedData } from '../modules/__mocks__/cache';
 const request = supertest.agent(app);
 
 describe('/api/announcements', () => {
+  it('returns announcements without null values', async () => {
+    // JSON.parse/stringify to enforce a deep copied array as to not mutate the original!
+    const announcements = JSON.parse(JSON.stringify(mockedAnnouncements)).slice(0, 1);
+    announcements[0].field_locations = announcements[0].field_locations.slice(0, 1);
+    announcements[0].field_locations[0].name = null;
+    announcements[0].field_pages[0].name = null;
+    mockCachedData.mockReturnValueOnce(JSON.stringify(announcements));
+    cache.getAsync = getAsync;
+    await request.get('/api/announcements').expect(200, [
+      {
+        id: 'd67dd5d0-5aab-4941-a1d1-fa81b51630a1',
+        title: 'SNAP for OSU Students',
+        body:
+          '   Supplemental Nutrition Assistance Program (SNAP) can help eligible students afford up to $194 in groceries each month. Find out if you are eligible and where to sign up. ',
+        bg_image: 'https://data.dx.oregonstate.edu/sites/default/files/2019-11/HSRC_Basket.jpg',
+        affiliation: [],
+        locations: [],
+        audiences: [],
+        pages: [],
+        action: {
+          title: 'Learn about SNAP',
+          link:
+            'https://proxy.qualtrics.com/proxy/?url=https%3A%2F%2Fbeav.es%2FSNAP&token=N1dOAVMk%2B5bq7mRPjK3wNU3g7zZLzG7DskwS4u5uySs%3D',
+        },
+      },
+    ]);
+  });
   it('returns uncached announcements', async () => {
     mockCachedData.mockReturnValue(null);
     cache.getAsync = getAsync;

--- a/src/api/__tests__/resources.test.ts
+++ b/src/api/__tests__/resources.test.ts
@@ -21,6 +21,30 @@ beforeAll(async () => {
 });
 
 describe('/resources', () => {
+  it('returns associated data without null values', async () => {
+    // JSON.parse/stringify to enforce a deep copied array as to not mutate the original!
+    const resources = JSON.parse(JSON.stringify(mockedResources)).slice(0, 1);
+    resources[0].field_locations = resources[0].field_locations.slice(0, 1);
+    resources[0].field_locations[0].name = null;
+    resources[0].field_audience[0].name = null;
+    const url = '/api/resources';
+    mockCachedData.mockReturnValue(JSON.stringify(resources));
+    cache.getAsync = getAsync;
+    await request.get(url).expect(200, [
+      {
+        id: '4c78c92a-baca-480d-97e7-384bb76e3b48',
+        title: 'Academic Advising',
+        link: 'https://catalog.oregonstate.edu/advising/',
+        iconName: 'fal.comments-alt',
+        affiliation: [],
+        locations: [],
+        audiences: ['Ecampus'],
+        categories: [],
+        synonyms: [],
+      },
+    ]);
+  });
+
   it('should contain an icon when one exists', async () => {
     const url = '/api/resources';
     mockCachedData.mockReturnValue(JSON.stringify(mockedResources));

--- a/src/api/modules/dx.ts
+++ b/src/api/modules/dx.ts
@@ -72,10 +72,13 @@ const mappedAnnouncements = (items: any[]): IAnnouncementResult[] => {
       let pages = [];
       let affiliation = [];
       let locations = [];
-      if (d.field_audience !== undefined) audiences = d.field_audience.map((a) => a.name);
-      if (d.field_pages !== undefined) pages = d.field_pages.map((a) => a.name);
-      if (d.field_affiliation !== undefined) affiliation = d.field_affiliation.map((a) => a.name);
-      if (d.field_locations !== undefined) locations = d.field_locations.map((a) => a.name);
+      if (d.field_audience !== undefined)
+        audiences = d.field_audience.map((a) => a.name).filter(Boolean);
+      if (d.field_pages !== undefined) pages = d.field_pages.map((a) => a.name).filter(Boolean);
+      if (d.field_affiliation !== undefined)
+        affiliation = d.field_affiliation.map((a) => a.name).filter(Boolean);
+      if (d.field_locations !== undefined)
+        locations = d.field_locations.map((a) => a.name).filter(Boolean);
       return {
         id: d.id,
         type: d.drupal_internal__name,
@@ -103,10 +106,10 @@ const mappedResources = (items: any[]): IResourceResult[] => {
     title: d.title,
     link: d.field_service_url?.uri,
     iconName: d.field_icon_name,
-    affiliation: d.field_affiliation.map((a) => a.name),
-    locations: d.field_locations.map((a) => a.name),
-    audiences: d.field_audience.map((a) => a.name),
-    categories: d.field_service_category.map((c) => c.name),
+    affiliation: d.field_affiliation.map((a) => a.name).filter(Boolean),
+    locations: d.field_locations.map((a) => a.name).filter(Boolean),
+    audiences: d.field_audience.map((a) => a.name).filter(Boolean),
+    categories: d.field_service_category.map((c) => c.name).filter(Boolean),
     synonyms: d.field_service_synonyms,
   }));
 };


### PR DESCRIPTION
`.filter(Boolean)` is a short-hand way to filter out any value that isn't `Truthy`.. to target `undefined` or `null` values that are possible in bad edge-cases of unsetting values in Drupal