### PR TITLE
Route handling fix and improvement

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -11,7 +11,6 @@ import MockStrategy from './utils/mock-strategy';
 import User, { GROUPS } from './api/models/user'; // eslint-disable-line no-unused-vars
 import { refreshOAuthToken } from './api/modules/canvas';
 import logger from './logger';
-import { returnUrl } from './utils/routing';
 import parseSamlResult from './utils/auth';
 
 interface Auth {
@@ -158,8 +157,6 @@ Auth.deserializeUser = (user, done) => {
 };
 
 Auth.login = (req: Request, res: Response, next: NextFunction) => {
-  if (req.query?.returnTo) req.session.returnUrl = req.query.returnTo;
-
   return passport.authenticate(['local', 'saml'], (err, user) => {
     logger().debug(`User authenticated: ${user.osuId}`);
     if (err) {
@@ -173,9 +170,8 @@ Auth.login = (req: Request, res: Response, next: NextFunction) => {
       if (innerErr) {
         return next(innerErr);
       }
-      const returnTo = returnUrl(req);
-      logger().debug(`Auth.login redirecting to: ${returnTo}`);
-      res.redirect(returnTo);
+      logger().debug(`Auth.login redirecting to: ${req.session.returnUrl}`);
+      res.redirect(req.session.returnUrl);
     });
   })(req, res, next);
 };

--- a/src/utils/__tests__/routing.test.ts
+++ b/src/utils/__tests__/routing.test.ts
@@ -27,6 +27,11 @@ describe('Routing helper', () => {
       handleReturnRequest(mockRequest(), {} as Response, () => {});
       expect(mockedSession()).toStrictEqual({ returnUrl: 'osu-dx://test' });
     });
+    it('returns a valid return expo uri', () => {
+      mockedQuery.mockReturnValue({ redirectUri: 'exp://test' });
+      handleReturnRequest(mockRequest(), {} as Response, () => {});
+      expect(mockedSession()).toStrictEqual({ returnUrl: 'exp://test' });
+    });
     it('returns the default for invalid redirect uris', () => {
       mockedQuery.mockReturnValue({ redirectUri: 'http://badbad.bad' });
       handleReturnRequest(mockRequest(), {} as Response, () => {});

--- a/src/utils/__tests__/routing.test.ts
+++ b/src/utils/__tests__/routing.test.ts
@@ -1,25 +1,40 @@
-import { returnUrl } from '../routing';
+import { Request, Response } from 'express'; // eslint-disable-line no-unused-vars
+import handleReturnRequest from '../routing';
 
-const mockRequest = {
-  session: {},
-  query: {}
+const mockedSession = jest.fn();
+const mockedQuery = jest.fn();
+
+const mockRequest = (): Request => {
+  const res: any = {};
+  res.session = mockedSession();
+  res.query = mockedQuery();
+  return res;
 };
+
 describe('Routing helper', () => {
-  describe('returnUrl', () => {
+  describe('handleReturnRequest', () => {
     beforeEach(() => {
-      mockRequest.session = {};
-      mockRequest.query = {};
+      mockedSession.mockReturnValue({});
+      mockedQuery.mockReturnValue({});
     });
-    it('returns a url from the session', () => {
-      mockRequest.session = { returnUrl: 'bob-ross' };
-      expect(returnUrl(mockRequest)).toBe('bob-ross');
+    it('returns a url', () => {
+      mockedQuery.mockReturnValue({ returnTo: '/bob-ross' });
+      handleReturnRequest(mockRequest(), {} as Response, () => {});
+      expect(mockedSession()).toStrictEqual({ returnUrl: '/bob-ross' });
     });
-    it('returns a url from the query string', () => {
-      mockRequest.query = { returnTo: 'rick-ross' };
-      expect(returnUrl(mockRequest)).toBe('rick-ross');
+    it('returns a valid return uri', () => {
+      mockedQuery.mockReturnValue({ redirectUri: 'osu-dx://test' });
+      handleReturnRequest(mockRequest(), {} as Response, () => {});
+      expect(mockedSession()).toStrictEqual({ returnUrl: 'osu-dx://test' });
     });
-    it('returns the root url', () => {
-      expect(returnUrl(mockRequest)).toBe('/');
+    it('returns the default for invalid redirect uris', () => {
+      mockedQuery.mockReturnValue({ redirectUri: 'http://badbad.bad' });
+      handleReturnRequest(mockRequest(), {} as Response, () => {});
+      expect(mockedSession()).toStrictEqual({ returnUrl: '/' });
+    });
+    it('returns the default when no query params are passed ', () => {
+      handleReturnRequest(mockRequest(), {} as Response, () => {});
+      expect(mockedSession()).toStrictEqual({ returnUrl: '/' });
     });
   });
 });

--- a/src/utils/routing.ts
+++ b/src/utils/routing.ts
@@ -1,16 +1,24 @@
+import { Request, Response, NextFunction } from 'express'; // eslint-disable-line no-unused-vars
 import logger from '../logger';
 
-export const returnUrl = (req: any) => {
-  if (req.session.returnUrl) {
-    logger().debug(`Found session returnUrl:${req.session.returnUrl}`);
-    return req.session.returnUrl;
-  }
-  if (req.query!.returnTo!) {
-    logger().debug(`Set session returnUrl:${req.query.returnTo}`);
-    req.session.returnUrl = req.query.returnTo;
-    return req.session.returnUrl;
-  }
-  return '/';
+const appRegex = RegExp(/^https?:\/\/[\w*.]?my\.oregonstate\.edu\/*/);
+export const isMobileRedirect = (uri: string): boolean => uri?.startsWith('osu-dx://');
+export const isAppUrl = (url: string = ''): boolean => appRegex.test(url) || url?.startsWith('/');
+
+export const handleReturnRequest = (req: Request, res: Response, next: NextFunction) => {
+  const { returnTo, redirectUri } = req.query;
+
+  let url = '/';
+  if (isAppUrl(returnTo)) url = returnTo;
+  if (isMobileRedirect(redirectUri)) url = redirectUri;
+  logger().debug(
+    `handleReturnRequest with query:${JSON.stringify(
+      req.query,
+    )}, setting session return url:${url}`,
+  );
+  req.session.returnUrl = url;
+
+  return next();
 };
 
-export default returnUrl;
+export default handleReturnRequest;

--- a/src/utils/routing.ts
+++ b/src/utils/routing.ts
@@ -2,7 +2,8 @@ import { Request, Response, NextFunction } from 'express'; // eslint-disable-lin
 import logger from '../logger';
 
 const appRegex = RegExp(/^https?:\/\/[\w*.]?my\.oregonstate\.edu\/*/);
-export const isMobileRedirect = (uri: string): boolean => uri?.startsWith('osu-dx://');
+export const isMobileRedirect = (uri: string): boolean =>
+  uri?.startsWith('osu-dx://') || uri?.startsWith('exp://');
 export const isAppUrl = (url: string = ''): boolean => appRegex.test(url) || url?.startsWith('/');
 
 export const handleReturnRequest = (req: Request, res: Response, next: NextFunction) => {


### PR DESCRIPTION
merge after #126 

Adds explicit handling of `returnTo` querystring param passed from the front end. The authentication flow from the front-end tries to append the users original location so that after authenticating they will be redirected to the page they were visiting. This update will enforce the redirect to be an application url or relative url (http://*.my.o.e, or /*). 

This handler also handles the case where a querystring `redirectUri` is provided by the dx-mobile app. The authentication flow for the mobile app will use the server provided SAML authentication but redirect the browser to a custom scheme (osu-dx://*) which the app is configured to handle (rather than the browser)